### PR TITLE
Added IsActive option for non-interactive usage

### DIFF
--- a/ProgressBar.m
+++ b/ProgressBar.m
@@ -68,6 +68,10 @@ classdef ProgressBar < matlab.System
     end
     
     properties (Logical, Nontunable)
+        % Boolean whether to activate progress bar at all
+        % useful for non-interactive / batch / hpc usage
+        IsActive = true;
+        
         % Boolean whether to use Unicode symbols or ASCII hash symbols (i.e. #)
         UseUnicode = true;
         
@@ -451,18 +455,19 @@ classdef ProgressBar < matlab.System
         function [] = printProgressBar(obj)
             % This method removes the old and prints the current bar to the screen
             % and saves the number of written characters for the next iteration
-            
-            % remove old previous bar
-            fprintf(1, ProgressBar.backspace(obj.NumWrittenCharacters));
-            
-            formatString = obj.returnFormatString();
-            argumentList = obj.returnArgumentList();
-            
-            % print new bar
-            obj.NumWrittenCharacters = fprintf(1, ...
-                formatString, ...
-                argumentList{:} ...
-                );
+            if obj.IsActive
+                % remove old previous bar
+                fprintf(1, ProgressBar.backspace(obj.NumWrittenCharacters));
+
+                formatString = obj.returnFormatString();
+                argumentList = obj.returnArgumentList();
+
+                % print new bar
+                obj.NumWrittenCharacters = fprintf(1, ...
+                    formatString, ...
+                    argumentList{:} ...
+                    );
+            end
         end
         
         


### PR DESCRIPTION
Low-tech option to skip display of progressbar. Certainly there are more elegant ways to skip progressbar display but that was the quick&dirty one.

Why do I need this option?
I also run my program in HPC environment via SLURM batch system. There the output is spammed by the refreshing progressbar. My program detects, whether it runs on hpc and therefore sets the IsActive option to zero.