### PR TITLE
Update ProgressBar.m

### DIFF
--- a/ProgressBar.m
+++ b/ProgressBar.m
@@ -251,7 +251,7 @@ classdef ProgressBar < matlab.System
                     obj.CurrentFont = s.matlab.fonts.codefont.Name.ActiveValue;
                     
                     % change to Courier New which is shipped by every Windows distro since Windows 3.1
-                    s.matlab.fonts.codefont.Name.TemporaryValue = ob.OVERRIDE_FONT_NAME;
+                    s.matlab.fonts.codefont.Name.TemporaryValue = obj.OVERRIDE_FONT_NAME;
                 end
                 
                 % add a new timer object with the standard tag name and hide it


### PR DESCRIPTION
Fix an issue in line #254, where a letter "j" is missing and the variable "obj" referring to the object itself cannot be resolved by MATLAB.

Also, I suggest let OVERRIDE_DEFAULT_FONT to be default "true" and "useUnicode" default false for maximum compatibility. (Although this is personal preference, and these changes are not made in this PR).